### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.krusader.json
+++ b/org.kde.krusader.json
@@ -17,6 +17,14 @@
         "--system-talk-name=org.freedesktop.UDisks2",
         "--talk-name=org.kde.StatusNotifierWatcher"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "lha",


### PR DESCRIPTION
The installed size reduced from 11.7 MB to 6.3 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.